### PR TITLE
Improve CI-CD

### DIFF
--- a/.github/actions/setup-mlops/action.yml
+++ b/.github/actions/setup-mlops/action.yml
@@ -1,0 +1,25 @@
+name: 'Setup MLOps Environment'
+description: 'Sets up Python, Google Cloud Auth, and dependencies'
+inputs:
+  gcp_credentials:
+    description: 'Service Account JSON Key'
+    required: true
+
+runs:
+  using: "composite"
+  steps:
+    - name: Setup Python
+      uses: actions/setup-python@v5
+      with:
+        python-version: "3.12"
+        cache: pip
+
+    - name: Login to Google Cloud
+      uses: google-github-actions/auth@v2
+      with:
+        credentials_json: "${{ inputs.gcp_credentials }}"
+
+    - name: Install dependencies
+      shell: bash
+      run: |
+        pip install --requirement requirements-freeze.txt

--- a/.github/workflows/mlops.yml
+++ b/.github/workflows/mlops.yml
@@ -55,6 +55,22 @@ jobs:
     needs: prepare_train_evaluate
     runs-on: ubuntu-24.04
     steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Login to Google Cloud
+        uses: google-github-actions/auth@v2
+        with:
+          credentials_json: "${{ secrets.GOOGLE_SERVICE_ACCOUNT_KEY }}"
+
+      - name: Setup Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+          cache: pip
+
+      - name: Install dependencies
+        run: pip install --requirement dvc==3.60.1
       - name: Download evaluation metrics artifact
         uses: actions/download-artifact@v4
         with:
@@ -117,7 +133,7 @@ jobs:
           cache: pip
 
       - name: Install dependencies
-        run: pip install bentoml=1.4.28
+        run: pip install bentoml==1.4.28
 
       - name: Log in to the Container registry
         uses: docker/login-action@v3

--- a/.github/workflows/mlops.yml
+++ b/.github/workflows/mlops.yml
@@ -89,15 +89,24 @@ jobs:
         env:
           REPO_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
+          # Fetch all other Git branches
+          git fetch --depth=1 origin main:main
+          
           echo "# Model Performance Report" > report.md
-          echo "## Metrics" >> report.md
           
-          # Si tu as un fichier metrics.json, utilise cat ou jq
-          # dvc metrics show --md >> report.md
+          echo "## Params workflow vs. main" >> report.md
+          dvc params diff main --md >> report.md
           
-          echo "## Visualizations" >> report.md
-          echo '![](evaluation/plots/baseline_model_finetuning_validation.png "Validation New")' >> report.md
-          echo '![](evaluation/plots/baseline_model_historical_validation.png "Validation Historical")' >> report.md
+          echo "## Metrics workflow vs. main" >> report.md
+          dvc metrics diff main --md >> report.md
+          
+          echo "## Validation on New dataset" >> report.md
+          echo '![](evaluation/plots/baseline_model_finetuning_validation.png "baseline_model_new_validation")' >> report.md
+          echo '![](evaluation/plots/finetuned_model_finetuning_validation.png "retrained_model_new_validation")' >> report.md
+
+          echo "## Validation on Historical dataset" >> report.md
+          echo '![](evaluation/plots/baseline_model_historical_validation.png "baseline_model_historical_validation")' >> report.md
+          echo '![](evaluation/plots/finetuned_model_historical_validation.png "retrained_model_historical_validation")' >> report.md
           
           cml comment update --target=pr --publish report.md
 

--- a/.github/workflows/mlops.yml
+++ b/.github/workflows/mlops.yml
@@ -9,6 +9,10 @@ on:
   schedule:
     - cron: '0 6 * * *'  # ex: run daily at 06:00 UTC
 
+permissions:
+  contents: write
+  pull-requests: write
+
 jobs:
   repro_dvc:
     runs-on: ubuntu-24.04
@@ -71,10 +75,12 @@ jobs:
           path: evaluation/*
 
       - name: Commit changes in `dvc.lock`
-        uses: stefanzweifel/git-auto-commit-action@v7
-        with:
-          commit_message: "feat(dvc): update dvc.lock"
-          file_pattern: dvc.lock
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+          git add dvc.lock 
+          git commit -m "feat(dvc): retrain model with new data"
+          git push origin $BRANCH_NAME
 
 #########################################################################################################
       - name: Open pull request using gh CLI

--- a/.github/workflows/mlops.yml
+++ b/.github/workflows/mlops.yml
@@ -2,8 +2,8 @@ name: MLOps CI/CD
 
 on:
   push:
-    branches: ["**"]      # Se lance sur tous les pushs
-  pull_request:           # Se lance sur les PRs
+    branches: ["**"]
+  pull_request:
     branches: [main]
 
 permissions:
@@ -12,7 +12,6 @@ permissions:
   id-token: write
 
 jobs:
-  # --- JOB 1: TRAIN ---
   train:
     runs-on: ubuntu-24.04
     steps:
@@ -29,12 +28,9 @@ jobs:
         run: dvc pull
 
       - name: Reproduce Pipeline (No Ingestion)
-        # On ne rejoue PAS 'ingestion'. On suppose que les données sont là.
         run: dvc repro prepare train_baseline train evaluate
 
       - name: Push Artifacts to DVC & Commit Lock
-        # On commit le lock SEULEMENT si c'est un push (pas sur PR pour éviter les conflits, sauf si désiré)
-        # Ici je le mets sur Push pour respecter ta demande "quand je push... commit dvc.lock"
         if: github.event_name == 'push'
         run: |
           dvc push
@@ -42,13 +38,10 @@ jobs:
           git config user.name "github-actions[bot]"
           git config user.email "github-actions[bot]@users.noreply.github.com"
           
-          # Si dvc.lock a changé (suite à l'entraînement)
-          if [[ -n $(git status --porcelain dvc.lock) ]]; then
-            git add dvc.lock
-            # [skip ci] est crucial ici pour éviter une boucle infinie !
-            git commit -m "feat(model): update model artifacts [skip ci]"
-            git push
-          fi
+          git add dvc.lock
+          git commit -m "feat(model): update model artifacts"
+          git push
+          
 
       - name: Upload BentoModel artifact
         uses: actions/upload-artifact@v4
@@ -64,7 +57,6 @@ jobs:
           path: evaluation/*
           overwrite: true
 
-  # --- JOB 2: CML REPORT (PR ONLY) ---
   cml:
     needs: train
     if: github.event_name == 'pull_request'
@@ -101,7 +93,7 @@ jobs:
           echo "## Metrics" >> report.md
           
           # Si tu as un fichier metrics.json, utilise cat ou jq
-          # dvc metrics show --md >> report.md (nécessite dvc installé, sinon juste cat les fichiers)
+          # dvc metrics show --md >> report.md
           
           echo "## Visualizations" >> report.md
           echo '![](evaluation/plots/baseline_model_finetuning_validation.png "Validation New")' >> report.md
@@ -109,7 +101,6 @@ jobs:
           
           cml comment update --target=pr --publish report.md
 
-  # --- JOB 3: DEPLOY (MAIN PUSH ONLY) ---
   deploy:
     needs: train
     if: github.event_name == 'push' && github.ref == 'refs/heads/main'
@@ -117,7 +108,6 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
-      # On setup l'env juste pour BentoML
       - name: Setup MLOps Env
         uses: ./.github/actions/setup-mlops
         with:

--- a/.github/workflows/mlops.yml
+++ b/.github/workflows/mlops.yml
@@ -16,6 +16,15 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v4
 
+#########################################################################################################
+      - name: Create new branch
+#        if : github.event_name == 'schedule'
+        run: |
+            BRANCH_NAME="continuous-learning/retrain-$(date +%Y%m%d-%H%M%S)"
+            echo "BRANCH_NAME=$BRANCH_NAME" >> $GITHUB_ENV
+            git checkout -b $BRANCH_NAME
+#########################################################################################################
+
       - name: Login to Google Cloud
         uses: google-github-actions/auth@v2
         with:
@@ -34,10 +43,12 @@ jobs:
         run: |
           dvc pull
 
+#########################################################################################################
       - name: Ingest new data from Meteo Suisse
-        if : github.event_name == 'schedule'
+#        if : github.event_name == 'schedule'
         run: |
           dvc repro ingestion
+#########################################################################################################
 
       - name: Reproduce prepare, train and evaluate stages
         run: |
@@ -64,6 +75,21 @@ jobs:
         with:
           commit_message: "feat(dvc): update dvc.lock"
           file_pattern: dvc.lock
+
+#########################################################################################################
+      - name: Open pull request using gh CLI
+#        if : github.event_name == 'schedule'
+        id: create_pr
+        run: |
+          PR_URL=$(gh pr create \
+            --title "Continuous Learning: Model Retrain $(date +%Y-%m-%d)" \
+            --body "This PR contains the results of the scheduled continuous learning workflow" \
+            --base main \
+            --head $(git rev-parse --abbrev-ref HEAD))
+          echo "PR_URL=$PR_URL" >> $GITHUB_ENV
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+#########################################################################################################
 
   cmf:
     # Run CMF only on pull requests, using artifact produced by prepare_train_evaluate in the same run

--- a/.github/workflows/mlops.yml
+++ b/.github/workflows/mlops.yml
@@ -28,7 +28,7 @@ jobs:
         run: dvc pull
 
       - name: Reproduce Pipeline (No Ingestion)
-        run: dvc repro prepare train_baseline train evaluate
+        run: dvc repro -f prepare train_baseline train evaluate
 
       - name: Push Artifacts to DVC & Commit Lock
         if: github.event_name == 'push'

--- a/.github/workflows/mlops.yml
+++ b/.github/workflows/mlops.yml
@@ -6,9 +6,11 @@ on:
       - main
       - feat/improve-ci-cd
   pull_request:
+  schedule:
+    - cron: '0 6 * * *'  # ex: run daily at 06:00 UTC
 
 jobs:
-  prepare_train_evaluate:
+  repro_dvc:
     runs-on: ubuntu-24.04
     steps:
       - name: Checkout repository
@@ -28,10 +30,21 @@ jobs:
       - name: Install dependencies
         run: pip install --requirement requirements-freeze.txt
 
-      - name: Prepare, train and evaluate
+      - name: Pull data from bucket
         run: |
           dvc pull
-          dvc repro prepare train evaluate
+
+      - name: Ingest new data from Meteo Suisse
+        if : github.event_name == 'schedule'
+        run: |
+          dvc repro ingestion
+
+      - name: Reproduce prepare, train and evaluate stages
+        run: |
+          dvc repro prepare train_baseline train evaluate
+
+      - name: Push new data and artifacts to bucket
+        run: |
           dvc push
 
       - name: Upload BentoModel artifact
@@ -51,8 +64,11 @@ jobs:
         with:
           commit_message: "feat(dvc): update dvc.lock"
           file_pattern: dvc.lock
+
   cmf:
-    needs: prepare_train_evaluate
+    # Run CMF only on pull requests, using artifact produced by prepare_train_evaluate in the same run
+    if: github.event_name == 'pull_request'
+    needs: repro_dvc
     runs-on: ubuntu-24.04
     steps:
       - name: Checkout repository
@@ -71,6 +87,7 @@ jobs:
 
       - name: Install dependencies
         run: pip install dvc==3.60.1
+
       - name: Download evaluation metrics artifact
         uses: actions/download-artifact@v4
         with:
@@ -86,37 +103,27 @@ jobs:
         env:
           REPO_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
-          # Add title to the report
           echo "# Baseline VS Retrained Model Performances" >> report.md
           echo "" >> report.md
           echo "**Retrain Date:** $(date +%Y-%m-%d)" >> report.md
           echo "" >> report.md
-          
-          # Create plots
-          
           echo "## Metrics" >> report.md
           echo "" >> report.md
           dvc metrics show --md >> report.md
           echo "" >> report.md
-          
           echo "## Validation on New dataset" >> report.md
-          
           echo '![](evaluation/plots/baseline_model_finetuning_validation.png "baseline_model_new_validation")' >> report.md
           echo '![](evaluation/plots/finetuned_model_finetuning_validation.png "retrained_model_new_validation")' >> report.md
-          
           echo "## Validation on Historical dataset" >> report.md
-          
           echo '![](evaluation/plots/baseline_model_historical_validation.png "baseline_model_historical_validation")' >> report.md
-          
           echo '![](evaluation/plots/finetuned_model_historical_validation.png "retrained_model_historical_validation")' >> report.md
-          
-          # Publish the CML report to the PR
-          cml comment update --target=pr --publish report.md  
+          cml comment update --target=pr --publish report.md
 
   deploy_model:
-    needs: prepare_train_evaluate
+    # Run deploy only on pushes to main; use artifact produced by prepare_train_evaluate in that run
+    if: github.event_name == 'push' && github.ref == 'refs/heads/main'
+    needs: repro_dvc
     runs-on: ubuntu-24.04
-    #if: github.ref == 'refs/heads/main'
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4

--- a/.github/workflows/mlops.yml
+++ b/.github/workflows/mlops.yml
@@ -2,12 +2,11 @@ name: MLOPS
 
 on:
   push:
-    branches:
-      - main
-      - feat/improve-ci-cd
+
   pull_request:
+  workflow_dispatch:         # Allow manual trigger
   schedule:
-    - cron: '0 6 * * *'  # ex: run daily at 06:00 UTC
+    - cron: '56 13 * *'  # ex: run daily at 06:00 UTC
 
 permissions:
   contents: write

--- a/.github/workflows/mlops.yml
+++ b/.github/workflows/mlops.yml
@@ -34,6 +34,12 @@ jobs:
           dvc repro prepare train evaluate
           dvc push
 
+      - name: Upload BentoModel artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: baseline-bentomodel
+          path: model/baseline.bentomodel
+
       - name: Commit changes in `dvc.lock`
         uses: stefanzweifel/git-auto-commit-action@v7
         with:
@@ -68,6 +74,12 @@ jobs:
           registry: ${{ secrets.GCP_CONTAINER_REGISTRY_HOST }}
           username: _json_key
           password: ${{ secrets.GOOGLE_SERVICE_ACCOUNT_KEY }}
+
+      - name: Download BentoModel artifact
+        uses: actions/download-artifact@v4
+        with:
+          name: baseline-bentomodel
+          path: model
 
       - name: Import the BentoML model
         run: bentoml models import model/baseline.bentomodel

--- a/.github/workflows/mlops.yml
+++ b/.github/workflows/mlops.yml
@@ -98,7 +98,7 @@ jobs:
 
   cmf:
     # Run CMF only on pull requests, using artifact produced by prepare_train_evaluate in the same run
-    if: github.event_name == 'pull_request'
+    if: (github.event_name == 'pull_request') || (github.event_name == 'schedule')
     needs: repro_dvc
     runs-on: ubuntu-24.04
     steps:

--- a/.github/workflows/mlops.yml
+++ b/.github/workflows/mlops.yml
@@ -100,6 +100,10 @@ jobs:
           echo "## Metrics workflow vs. main" >> report.md
           dvc metrics diff main --md >> report.md
           
+          echo "## Training plot" >> report.md
+          echo '![](evaluation/plots/baseline_train_history.png "baseline_model_training")' >> report.md
+          echo '![](evaluation/plots/train_history.png "retrained_model_training")' >> report.md
+          
           echo "## Validation on New dataset" >> report.md
           echo '![](evaluation/plots/baseline_model_finetuning_validation.png "baseline_model_new_validation")' >> report.md
           echo '![](evaluation/plots/finetuned_model_finetuning_validation.png "retrained_model_new_validation")' >> report.md

--- a/.github/workflows/mlops.yml
+++ b/.github/workflows/mlops.yml
@@ -1,96 +1,53 @@
-name: MLOPS
+name: MLOps CI/CD
 
 on:
   push:
-    branches: ["**"]
-  pull_request:
+    branches: ["**"]      # Se lance sur tous les pushs
+  pull_request:           # Se lance sur les PRs
     branches: [main]
-  schedule:
-    - cron: '0 9 * * 1'
-  workflow_dispatch:
-    inputs:
-        version:
-          description: "Version name"
-          required: true
-          default: "minor"
-          type: choice
-          options:
-            - major
-            - minor
-            - patch
 
 permissions:
   contents: write
   pull-requests: write
-  issues: write
   id-token: write
 
-env:
-  TargetBranch: ${{ github.ref_name }}
-
 jobs:
-  repro_dvc:
+  # --- JOB 1: TRAIN ---
+  train:
     runs-on: ubuntu-24.04
     steps:
-      - name: Checkout repository
-        uses: actions/checkout@v4
+      - uses: actions/checkout@v4
         with:
           fetch-depth: 0
 
-      # --- MODIFICATION ICI ---
-      - name: Setup Branch for Schedule (or Manual Test)
-        # On lance cette étape si c'est le schedule OU un déclenchement manuel
-        if: github.event_name == 'schedule' || github.event_name == 'workflow_dispatch'
-        run: |
-          # On ajoute un préfixe 'manual' si c'est manuel pour différencier, ou on garde le même
-          TYPE="retrain"
-          [[ "${{ github.event_name }}" == "workflow_dispatch" ]] && TYPE="manual-test"
-          
-          NEW_BRANCH="continuous-learning/${TYPE}-$(date +%Y%m%d-%H%M%S)"
-          echo "TargetBranch=$NEW_BRANCH" >> $GITHUB_ENV
-          git checkout -b $NEW_BRANCH
-          echo "Branche de travail: $NEW_BRANCH"
-
-      - name: Login to Google Cloud
-        uses: google-github-actions/auth@v2
+      - name: Setup MLOps Env
+        uses: ./.github/actions/setup-mlops
         with:
-          credentials_json: "${{ secrets.GOOGLE_SERVICE_ACCOUNT_KEY }}"
+          gcp_credentials: ${{ secrets.GOOGLE_SERVICE_ACCOUNT_KEY }}
 
-      - name: Setup Python
-        uses: actions/setup-python@v5
-        with:
-          python-version: "3.12"
-          cache: pip
-
-      - name: Install dependencies
-        run: pip install --requirement requirements-freeze.txt
-
-      - name: Pull data from bucket
+      - name: Pull Data
         run: dvc pull
 
-      # --- MODIFICATION ICI ---
-      - name: Ingest new data from Meteo Suisse
-        if: github.event_name == 'schedule' || github.event_name == 'workflow_dispatch'
-        run: dvc repro ingestion
-
-      - name: Reproduce pipeline
+      - name: Reproduce Pipeline (No Ingestion)
+        # On ne rejoue PAS 'ingestion'. On suppose que les données sont là.
         run: dvc repro prepare train_baseline train evaluate
 
-      # --- MODIFICATION ICI ---
-      - name: Push data to bucket & Commit dvc.lock
-        # On push si c'est un push normal, un schedule, ou un test manuel
-        if: github.event_name == 'push' || github.event_name == 'schedule' || github.event_name == 'workflow_dispatch'
+      - name: Push Artifacts to DVC & Commit Lock
+        # On commit le lock SEULEMENT si c'est un push (pas sur PR pour éviter les conflits, sauf si désiré)
+        # Ici je le mets sur Push pour respecter ta demande "quand je push... commit dvc.lock"
+        if: github.event_name == 'push'
         run: |
           dvc push
+          
           git config user.name "github-actions[bot]"
           git config user.email "github-actions[bot]@users.noreply.github.com"
           
+          # Si dvc.lock a changé (suite à l'entraînement)
           if [[ -n $(git status --porcelain dvc.lock) ]]; then
             git add dvc.lock
-            git commit -m "chore(dvc): update dvc.lock [skip ci]"
-            git push origin ${{ env.TargetBranch }}
-          else
-            echo "No changes in dvc.lock"
+            # [skip ci] est crucial ici pour éviter une boucle infinie !
+            git commit -m "feat(model): update model artifacts [skip ci]"
+            git push
           fi
 
       - name: Upload BentoModel artifact
@@ -107,28 +64,13 @@ jobs:
           path: evaluation/*
           overwrite: true
 
-      # --- MODIFICATION ICI ---
-      - name: Open pull request
-        if: github.event_name == 'schedule' || github.event_name == 'workflow_dispatch'
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        run: |
-          gh pr create \
-            --title "Continuous Learning: Model Retrain $(date +%Y-%m-%d)" \
-            --body "Auto-generated PR from ${{ github.event_name }} workflow." \
-            --base main \
-            --head ${{ env.TargetBranch }}
-
+  # --- JOB 2: CML REPORT (PR ONLY) ---
   cml:
-    needs: repro_dvc
+    needs: train
     if: github.event_name == 'pull_request'
     runs-on: ubuntu-24.04
     steps:
-      # ... (Le reste du job CML reste identique) ...
-      # CML se lancera automatiquement car le job repro_dvc manuel va créer une PR
-      # et GitHub détectera l'événement "pull_request"
-      - name: Checkout repository
-        uses: actions/checkout@v4
+      - uses: actions/checkout@v4
 
       - name: Setup Python
         uses: actions/setup-python@v5
@@ -137,30 +79,88 @@ jobs:
           cache: pip
 
       - name: Install dependencies
-        run: pip install dvc==3.60.1
+        run: |
+          pip install dvc==3.60.1
 
       - name: Setup CML
         uses: iterative/setup-cml@v2
         with:
           version: '0.20.6'
-      - name: Download evaluation metrics artifact
+
+      - name: Download metrics
         uses: actions/download-artifact@v4
         with:
           name: evaluation-metrics
           path: evaluation
-      - name: Create CML report
+
+      - name: Create CML Report
         env:
           REPO_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
-          echo "# Report" > report.md
-          dvc metrics show --md >> report.md
+          echo "# Model Performance Report" > report.md
+          echo "## Metrics" >> report.md
+          
+          # Si tu as un fichier metrics.json, utilise cat ou jq
+          # dvc metrics show --md >> report.md (nécessite dvc installé, sinon juste cat les fichiers)
+          
+          echo "## Visualizations" >> report.md
+          echo '![](evaluation/plots/baseline_model_finetuning_validation.png "Validation New")' >> report.md
+          echo '![](evaluation/plots/baseline_model_historical_validation.png "Validation Historical")' >> report.md
+          
           cml comment update --target=pr --publish report.md
 
-  deploy_model:
-    # Le deploy ne change pas, il ne se lance que sur push main
+  # --- JOB 3: DEPLOY (MAIN PUSH ONLY) ---
+  deploy:
+    needs: train
     if: github.event_name == 'push' && github.ref == 'refs/heads/main'
-    needs: repro_dvc
     runs-on: ubuntu-24.04
     steps:
-       # ... tes étapes de déploiement ...
-       - run: echo "Deploying..."
+      - uses: actions/checkout@v4
+
+      # On setup l'env juste pour BentoML
+      - name: Setup MLOps Env
+        uses: ./.github/actions/setup-mlops
+        with:
+          gcp_credentials: ${{ secrets.GOOGLE_SERVICE_ACCOUNT_KEY }}
+
+      - name: Install Deploy Deps
+        run: pip install bentoml google-cloud-artifact-registry
+
+      - name: Login to Docker
+        uses: docker/login-action@v3
+        with:
+          registry: ${{ secrets.GCP_CONTAINER_REGISTRY_HOST }}
+          username: _json_key
+          password: ${{ secrets.GOOGLE_SERVICE_ACCOUNT_KEY }}
+
+      - name: Download Model
+        uses: actions/download-artifact@v4
+        with:
+          name: baseline-bentomodel
+          path: model
+
+      - name: Build & Push Docker
+        run: |
+          bentoml models import model/baseline.bentomodel
+          
+          # Récupération automatique du tag
+          MODEL_TAG=$(bentoml models list --output json | jq -r '.[0].tag')
+          
+          bentoml containerize $MODEL_TAG \
+             --image-tag ${{ secrets.GCP_CONTAINER_REGISTRY_HOST }}/air-temperature-regressor:latest \
+             --image-tag ${{ secrets.GCP_CONTAINER_REGISTRY_HOST }}/air-temperature-regressor:${{ github.sha }}
+             
+          docker push --all-tags ${{ secrets.GCP_CONTAINER_REGISTRY_HOST }}/air-temperature-regressor
+
+      - name: Get GKE Credentials
+        uses: google-github-actions/get-gke-credentials@v3
+        with:
+          cluster_name: ${{ secrets.GCP_K8S_CLUSTER_NAME }}
+          location: ${{ secrets.GCP_K8S_CLUSTER_ZONE }}
+
+      - name: Deploy to K8s
+        run: |
+          kubectl set image deployment/air-temperature-regressor \
+            air-temperature-regressor=${{ secrets.GCP_CONTAINER_REGISTRY_HOST }}/air-temperature-regressor:${{ github.sha }}
+          
+          kubectl rollout status deployment/air-temperature-regressor

--- a/.github/workflows/mlops.yml
+++ b/.github/workflows/mlops.yml
@@ -7,7 +7,17 @@ on:
     branches: [main]
   schedule:
     - cron: '0 9 * * 1'
-  workflow_dispatch:      # Permet le lancement manuel
+  workflow_dispatch:
+    inputs:
+        version:
+          description: "Version name"
+          required: true
+          default: "minor"
+          type: choice
+          options:
+            - major
+            - minor
+            - patch
 
 permissions:
   contents: write
@@ -119,6 +129,16 @@ jobs:
       # et GitHub détectera l'événement "pull_request"
       - name: Checkout repository
         uses: actions/checkout@v4
+
+      - name: Setup Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+          cache: pip
+
+      - name: Install dependencies
+        run: pip install dvc==3.60.1
+
       - name: Setup CML
         uses: iterative/setup-cml@v2
         with:

--- a/.github/workflows/mlops.yml
+++ b/.github/workflows/mlops.yml
@@ -6,7 +6,7 @@ on:
   pull_request:
   workflow_dispatch:         # Allow manual trigger
   schedule:
-    - cron: '56 13 * *'  # ex: run daily at 06:00 UTC
+    - cron: '0 9 * *'  # ex: run daily at 06:00 UTC
 
 permissions:
   contents: write

--- a/.github/workflows/mlops.yml
+++ b/.github/workflows/mlops.yml
@@ -72,14 +72,14 @@ jobs:
           path: evaluation/*
 
       - name: Commit changes in `dvc.lock`
-        env:
-          BRANCH_NAME: ${{ github.head_ref || github.ref_name }}
         run: |
+          echo ${{ github.head_ref || github.ref_name }}
           git config user.name "github-actions[bot]"
           git config user.email "github-actions[bot]@users.noreply.github.com"
           git add dvc.lock 
           git commit -m "feat(dvc): retrain model with new data"
           git push origin $BRANCH_NAME
+          git log -3
 
 #########################################################################################################
       - name: Open pull request using gh CLI

--- a/.github/workflows/mlops.yml
+++ b/.github/workflows/mlops.yml
@@ -3,10 +3,8 @@ name: MLOPS
 on:
   push:
 
-  pull_request:
-  workflow_dispatch:         # Allow manual trigger
-  schedule:
-    - cron: '0 9 * *'  # ex: run daily at 06:00 UTC
+#  pull_request:
+
 
 permissions:
   contents: write
@@ -21,7 +19,7 @@ jobs:
 
 #########################################################################################################
       - name: Create new branch
-        if : github.event_name == 'schedule'
+#        if : github.event_name == 'schedule'
         run: |
             BRANCH_NAME="continuous-learning/retrain-$(date +%Y%m%d-%H%M%S)"
             echo "BRANCH_NAME=$BRANCH_NAME" >> $GITHUB_ENV
@@ -48,7 +46,7 @@ jobs:
 
 #########################################################################################################
       - name: Ingest new data from Meteo Suisse
-        if : github.event_name == 'schedule'
+#        if : github.event_name == 'schedule'
         run: |
           dvc repro ingestion
 #########################################################################################################
@@ -85,7 +83,7 @@ jobs:
 
 #########################################################################################################
       - name: Open pull request using gh CLI
-        if : github.event_name == 'schedule'
+#        if : github.event_name == 'schedule'
         id: create_pr
         run: |
           PR_URL=$(gh pr create \

--- a/.github/workflows/mlops.yml
+++ b/.github/workflows/mlops.yml
@@ -94,7 +94,7 @@ jobs:
             --head $(git rev-parse --abbrev-ref HEAD))
           echo "PR_URL=$PR_URL" >> $GITHUB_ENV
         env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITHUB_TOKEN: ${{ secrets.PAT_PR_UPDATE_DATA }}
 #########################################################################################################
 
   cmf:

--- a/.github/workflows/mlops.yml
+++ b/.github/workflows/mlops.yml
@@ -4,12 +4,41 @@ on:
   push:
     branches:
       - main
-
+      - feat/improve-ci-cd
   pull_request:
 
 jobs:
-  mlpos:
+  prepare_train_evaluate:
     runs-on: ubuntu-24.04
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Setup Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+          cache: pip
+
+      - name: Install dependencies
+        run: pip install --requirement requirements-freeze.txt
+
+      - name: Prepare, train and evaluate
+        run: |
+          dvc pull
+          dvc repro prepare train evaluate
+          dvc push
+
+      - name: Commit changes in `dvc.lock`
+        uses: stefanzweifel/git-auto-commit-action@v7
+        with:
+          commit_message: "feat(dvc): update dvc.lock"
+          file_pattern: dvc.lock
+
+  deploy_model:
+    needs: prepare_train_evaluate
+    runs-on: ubuntu-24.04
+    #if: github.ref == 'refs/heads/main'
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
@@ -28,52 +57,37 @@ jobs:
       - name: Install dependencies
         run: pip install --requirement requirements-freeze.txt
 
-      - name: Prepare, train and evaluate
-        run: |
-          dvc pull
-          dvc repro prepare train evaluate
-          dvc push
-
-      - name: Commit changes in dvc.lock
-        uses: stefanzweifel/git-auto-commit-action@v7
-        with:
-          commit_message: "feat(dvc): update dvc.lock"
-          file_pattern: dvc.lock
-      #######################################################################
       - name: Log in to the Container registry
         uses: docker/login-action@v3
         with:
           registry: ${{ secrets.GCP_CONTAINER_REGISTRY_HOST }}
           username: _json_key
           password: ${{ secrets.GOOGLE_SERVICE_ACCOUNT_KEY }}
+
       - name: Import the BentoML model
-        if: github.ref == 'refs/heads/main'
         run: bentoml models import model/baseline.bentomodel
+
       - name: Build the BentoML model artifact
-        if: github.ref == 'refs/heads/main'
         run: bentoml build src
+
       - name: Containerize and publish the BentoML model artifact Docker image
-        if: github.ref == 'refs/heads/main'
         run: |
-          # Containerize the Bento
           bentoml containerize air_temperature_regressor:latest \
             --image-tag ${{ secrets.GCP_CONTAINER_REGISTRY_HOST }}/air-temperature-regressor:latest \
             --image-tag ${{ secrets.GCP_CONTAINER_REGISTRY_HOST }}/air-temperature-regressor:${{ github.sha }}
-          # Push the container to the Container Registry
           docker push --all-tags ${{ secrets.GCP_CONTAINER_REGISTRY_HOST }}/air-temperature-regressor
-      #######################################################################
+
       - name: Get Google Cloud's Kubernetes credentials
-        if: github.ref == 'refs/heads/main'
         uses: google-github-actions/get-gke-credentials@v3
         with:
           cluster_name: ${{ secrets.GCP_K8S_CLUSTER_NAME }}
           location: ${{ secrets.GCP_K8S_CLUSTER_ZONE }}
-      - name: Update the Kubernetes deployment
-        if: github.ref == 'refs/heads/main'
+
+      - name: Update the Kubernetes deployment image in `kubernetes/deployment.yaml`
         run: |
           yq -i '.spec.template.spec.containers[0].image = "${{ secrets.GCP_CONTAINER_REGISTRY_HOST }}/air-temperature-regressor:${{ github.sha }}"' kubernetes/deployment.yaml
+
       - name: Deploy the model on Kubernetes
-        if: github.ref == 'refs/heads/main'
         run: |
           kubectl apply \
             -f kubernetes/deployment.yaml \

--- a/.github/workflows/mlops.yml
+++ b/.github/workflows/mlops.yml
@@ -122,9 +122,6 @@ jobs:
         with:
           gcp_credentials: ${{ secrets.GOOGLE_SERVICE_ACCOUNT_KEY }}
 
-      - name: Install Deploy Deps
-        run: pip install bentoml google-cloud-artifact-registry
-
       - name: Login to Docker
         uses: docker/login-action@v3
         with:
@@ -132,34 +129,40 @@ jobs:
           username: _json_key
           password: ${{ secrets.GOOGLE_SERVICE_ACCOUNT_KEY }}
 
-      - name: Download Model
+      - name: Download BentoModel artifact
         uses: actions/download-artifact@v4
         with:
           name: baseline-bentomodel
           path: model
 
-      - name: Build & Push Docker
+      - name: Import the BentoML model
         run: |
           bentoml models import model/baseline.bentomodel
+
+      - name: Build the BentoML model artifact
+        run: |
+          bentoml build src
+
+      - name: Containerize and publish the BentoML model artifact Docker image
+        run: |
+          bentoml containerize air_temperature_regressor:latest \
+            --image-tag ${{ secrets.GCP_CONTAINER_REGISTRY_HOST }}/air-temperature-regressor:latest \
+            --image-tag ${{ secrets.GCP_CONTAINER_REGISTRY_HOST }}/air-temperature-regressor:${{ github.sha }}
           
-          # Récupération automatique du tag
-          MODEL_TAG=$(bentoml models list --output json | jq -r '.[0].tag')
-          
-          bentoml containerize $MODEL_TAG \
-             --image-tag ${{ secrets.GCP_CONTAINER_REGISTRY_HOST }}/air-temperature-regressor:latest \
-             --image-tag ${{ secrets.GCP_CONTAINER_REGISTRY_HOST }}/air-temperature-regressor:${{ github.sha }}
-             
           docker push --all-tags ${{ secrets.GCP_CONTAINER_REGISTRY_HOST }}/air-temperature-regressor
 
-      - name: Get GKE Credentials
+      - name: Get Google Cloud's Kubernetes credentials
         uses: google-github-actions/get-gke-credentials@v3
         with:
           cluster_name: ${{ secrets.GCP_K8S_CLUSTER_NAME }}
           location: ${{ secrets.GCP_K8S_CLUSTER_ZONE }}
 
-      - name: Deploy to K8s
+      - name: Update the Kubernetes deployment image in `kubernetes/deployment.yaml`
         run: |
-          kubectl set image deployment/air-temperature-regressor \
-            air-temperature-regressor=${{ secrets.GCP_CONTAINER_REGISTRY_HOST }}/air-temperature-regressor:${{ github.sha }}
-          
-          kubectl rollout status deployment/air-temperature-regressor
+          yq -i '.spec.template.spec.containers[0].image = "${{ secrets.GCP_CONTAINER_REGISTRY_HOST }}/air-temperature-regressor:${{ github.sha }}"' kubernetes/deployment.yaml
+
+      - name: Deploy the model on Kubernetes
+        run: |               
+          kubectl apply \               
+            -f kubernetes/deployment.yaml \
+            -f kubernetes/service.yaml

--- a/.github/workflows/mlops.yml
+++ b/.github/workflows/mlops.yml
@@ -70,7 +70,7 @@ jobs:
           cache: pip
 
       - name: Install dependencies
-        run: pip install --requirement dvc==3.60.1
+        run: pip install dvc==3.60.1
       - name: Download evaluation metrics artifact
         uses: actions/download-artifact@v4
         with:
@@ -133,7 +133,7 @@ jobs:
           cache: pip
 
       - name: Install dependencies
-        run: pip install bentoml==1.4.28
+        run: pip install --requirement requirements-freeze.txt
 
       - name: Log in to the Container registry
         uses: docker/login-action@v3

--- a/.github/workflows/mlops.yml
+++ b/.github/workflows/mlops.yml
@@ -14,6 +14,11 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v4
 
+      - name: Login to Google Cloud
+        uses: google-github-actions/auth@v2
+        with:
+          credentials_json: "${{ secrets.GOOGLE_SERVICE_ACCOUNT_KEY }}"
+
       - name: Setup Python
         uses: actions/setup-python@v5
         with:

--- a/.github/workflows/mlops.yml
+++ b/.github/workflows/mlops.yml
@@ -40,11 +40,62 @@ jobs:
           name: baseline-bentomodel
           path: model/baseline.bentomodel
 
+      - name: Upload evaluation metrics
+        uses: actions/upload-artifact@v4
+        with:
+          name: evaluation-metrics
+          path: evaluation/*
+
       - name: Commit changes in `dvc.lock`
         uses: stefanzweifel/git-auto-commit-action@v7
         with:
           commit_message: "feat(dvc): update dvc.lock"
           file_pattern: dvc.lock
+  cmf:
+    needs: prepare_train_evaluate
+    runs-on: ubuntu-24.04
+    steps:
+      - name: Download evaluation metrics artifact
+        uses: actions/download-artifact@v4
+        with:
+          name: evaluation-metrics
+          path: evaluation
+
+      - name: Setup CML
+        uses: iterative/setup-cml@v2
+        with:
+          version: '0.20.6'
+
+      - name: Create CML report
+        env:
+          REPO_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          # Add title to the report
+          echo "# Baseline VS Retrained Model Performances" >> report.md
+          echo "" >> report.md
+          echo "**Retrain Date:** $(date +%Y-%m-%d)" >> report.md
+          echo "" >> report.md
+          
+          # Create plots
+          
+          echo "## Metrics" >> report.md
+          echo "" >> report.md
+          dvc metrics show --md >> report.md
+          echo "" >> report.md
+          
+          echo "## Validation on New dataset" >> report.md
+          
+          echo '![](evaluation/plots/baseline_model_finetuning_validation.png "baseline_model_new_validation")' >> report.md
+          echo '![](evaluation/plots/finetuned_model_finetuning_validation.png "retrained_model_new_validation")' >> report.md
+          
+          echo "## Validation on Historical dataset" >> report.md
+          
+          echo '![](evaluation/plots/baseline_model_historical_validation.png "baseline_model_historical_validation")' >> report.md
+          
+          echo '![](evaluation/plots/finetuned_model_historical_validation.png "retrained_model_historical_validation")' >> report.md
+          
+          # Publish the CML report to the PR
+          cml comment update --target=pr --publish report.md  
 
   deploy_model:
     needs: prepare_train_evaluate
@@ -66,7 +117,7 @@ jobs:
           cache: pip
 
       - name: Install dependencies
-        run: pip install --requirement requirements-freeze.txt
+        run: pip install bentoml=1.4.28
 
       - name: Log in to the Container registry
         uses: docker/login-action@v3

--- a/.github/workflows/mlops.yml
+++ b/.github/workflows/mlops.yml
@@ -22,7 +22,7 @@ jobs:
 
 #########################################################################################################
       - name: Create new branch
-#        if : github.event_name == 'schedule'
+        if : github.event_name == 'schedule'
         run: |
             BRANCH_NAME="continuous-learning/retrain-$(date +%Y%m%d-%H%M%S)"
             echo "BRANCH_NAME=$BRANCH_NAME" >> $GITHUB_ENV
@@ -49,7 +49,7 @@ jobs:
 
 #########################################################################################################
       - name: Ingest new data from Meteo Suisse
-#        if : github.event_name == 'schedule'
+        if : github.event_name == 'schedule'
         run: |
           dvc repro ingestion
 #########################################################################################################
@@ -75,6 +75,8 @@ jobs:
           path: evaluation/*
 
       - name: Commit changes in `dvc.lock`
+        env:
+          BRANCH_NAME: ${{ github.head_ref || github.ref_name }}
         run: |
           git config user.name "github-actions[bot]"
           git config user.email "github-actions[bot]@users.noreply.github.com"
@@ -84,7 +86,7 @@ jobs:
 
 #########################################################################################################
       - name: Open pull request using gh CLI
-#        if : github.event_name == 'schedule'
+        if : github.event_name == 'schedule'
         id: create_pr
         run: |
           PR_URL=$(gh pr create \

--- a/.github/workflows/mlops.yml
+++ b/.github/workflows/mlops.yml
@@ -2,13 +2,21 @@ name: MLOPS
 
 on:
   push:
-
-#  pull_request:
-
+    branches: ["**"]
+  pull_request:
+    branches: [main]
+  schedule:
+    - cron: '0 9 * * 1'
+  workflow_dispatch:      # Permet le lancement manuel
 
 permissions:
   contents: write
   pull-requests: write
+  issues: write
+  id-token: write
+
+env:
+  TargetBranch: ${{ github.ref_name }}
 
 jobs:
   repro_dvc:
@@ -16,15 +24,22 @@ jobs:
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
 
-#########################################################################################################
-      - name: Create new branch
-#        if : github.event_name == 'schedule'
+      # --- MODIFICATION ICI ---
+      - name: Setup Branch for Schedule (or Manual Test)
+        # On lance cette étape si c'est le schedule OU un déclenchement manuel
+        if: github.event_name == 'schedule' || github.event_name == 'workflow_dispatch'
         run: |
-            BRANCH_NAME="continuous-learning/retrain-$(date +%Y%m%d-%H%M%S)"
-            echo "BRANCH_NAME=$BRANCH_NAME" >> $GITHUB_ENV
-            git checkout -b $BRANCH_NAME
-#########################################################################################################
+          # On ajoute un préfixe 'manual' si c'est manuel pour différencier, ou on garde le même
+          TYPE="retrain"
+          [[ "${{ github.event_name }}" == "workflow_dispatch" ]] && TYPE="manual-test"
+          
+          NEW_BRANCH="continuous-learning/${TYPE}-$(date +%Y%m%d-%H%M%S)"
+          echo "TargetBranch=$NEW_BRANCH" >> $GITHUB_ENV
+          git checkout -b $NEW_BRANCH
+          echo "Branche de travail: $NEW_BRANCH"
 
       - name: Login to Google Cloud
         uses: google-github-actions/auth@v2
@@ -41,176 +56,91 @@ jobs:
         run: pip install --requirement requirements-freeze.txt
 
       - name: Pull data from bucket
-        run: |
-          dvc pull
+        run: dvc pull
 
-#########################################################################################################
+      # --- MODIFICATION ICI ---
       - name: Ingest new data from Meteo Suisse
-#        if : github.event_name == 'schedule'
-        run: |
-          dvc repro ingestion
-#########################################################################################################
+        if: github.event_name == 'schedule' || github.event_name == 'workflow_dispatch'
+        run: dvc repro ingestion
 
-      - name: Reproduce prepare, train and evaluate stages
-        run: |
-          dvc repro prepare train_baseline train evaluate
+      - name: Reproduce pipeline
+        run: dvc repro prepare train_baseline train evaluate
 
-      - name: Push new data and artifacts to bucket
+      # --- MODIFICATION ICI ---
+      - name: Push data to bucket & Commit dvc.lock
+        # On push si c'est un push normal, un schedule, ou un test manuel
+        if: github.event_name == 'push' || github.event_name == 'schedule' || github.event_name == 'workflow_dispatch'
         run: |
           dvc push
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+          
+          if [[ -n $(git status --porcelain dvc.lock) ]]; then
+            git add dvc.lock
+            git commit -m "chore(dvc): update dvc.lock [skip ci]"
+            git push origin ${{ env.TargetBranch }}
+          else
+            echo "No changes in dvc.lock"
+          fi
 
       - name: Upload BentoModel artifact
         uses: actions/upload-artifact@v4
         with:
           name: baseline-bentomodel
           path: model/baseline.bentomodel
+          overwrite: true
 
       - name: Upload evaluation metrics
         uses: actions/upload-artifact@v4
         with:
           name: evaluation-metrics
           path: evaluation/*
+          overwrite: true
 
-      - name: Commit changes in `dvc.lock`
-        run: |
-          echo ${{ github.head_ref || github.ref_name }}
-          git config user.name "github-actions[bot]"
-          git config user.email "github-actions[bot]@users.noreply.github.com"
-          git add dvc.lock 
-          git commit -m "feat(dvc): retrain model with new data"
-          git push origin $BRANCH_NAME
-          git log -3
-
-#########################################################################################################
-      - name: Open pull request using gh CLI
-#        if : github.event_name == 'schedule'
-        id: create_pr
-        run: |
-          PR_URL=$(gh pr create \
-            --title "Continuous Learning: Model Retrain $(date +%Y-%m-%d)" \
-            --body "This PR contains the results of the scheduled continuous learning workflow" \
-            --base main \
-            --head $(git rev-parse --abbrev-ref HEAD))
-          echo "PR_URL=$PR_URL" >> $GITHUB_ENV
+      # --- MODIFICATION ICI ---
+      - name: Open pull request
+        if: github.event_name == 'schedule' || github.event_name == 'workflow_dispatch'
         env:
-          GITHUB_TOKEN: ${{ secrets.PAT_PR_UPDATE_DATA }}
-#########################################################################################################
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          gh pr create \
+            --title "Continuous Learning: Model Retrain $(date +%Y-%m-%d)" \
+            --body "Auto-generated PR from ${{ github.event_name }} workflow." \
+            --base main \
+            --head ${{ env.TargetBranch }}
 
-  cmf:
-    # Run CMF only on pull requests, using artifact produced by prepare_train_evaluate in the same run
-    if: (github.event_name == 'pull_request') || (github.event_name == 'schedule')
+  cml:
     needs: repro_dvc
+    if: github.event_name == 'pull_request'
     runs-on: ubuntu-24.04
     steps:
+      # ... (Le reste du job CML reste identique) ...
+      # CML se lancera automatiquement car le job repro_dvc manuel va créer une PR
+      # et GitHub détectera l'événement "pull_request"
       - name: Checkout repository
         uses: actions/checkout@v4
-
-      - name: Login to Google Cloud
-        uses: google-github-actions/auth@v2
+      - name: Setup CML
+        uses: iterative/setup-cml@v2
         with:
-          credentials_json: "${{ secrets.GOOGLE_SERVICE_ACCOUNT_KEY }}"
-
-      - name: Setup Python
-        uses: actions/setup-python@v5
-        with:
-          python-version: "3.12"
-          cache: pip
-
-      - name: Install dependencies
-        run: pip install dvc==3.60.1
-
+          version: '0.20.6'
       - name: Download evaluation metrics artifact
         uses: actions/download-artifact@v4
         with:
           name: evaluation-metrics
           path: evaluation
-
-      - name: Setup CML
-        uses: iterative/setup-cml@v2
-        with:
-          version: '0.20.6'
-
       - name: Create CML report
         env:
           REPO_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
-          echo "# Baseline VS Retrained Model Performances" >> report.md
-          echo "" >> report.md
-          echo "**Retrain Date:** $(date +%Y-%m-%d)" >> report.md
-          echo "" >> report.md
-          echo "## Metrics" >> report.md
-          echo "" >> report.md
+          echo "# Report" > report.md
           dvc metrics show --md >> report.md
-          echo "" >> report.md
-          echo "## Validation on New dataset" >> report.md
-          echo '![](evaluation/plots/baseline_model_finetuning_validation.png "baseline_model_new_validation")' >> report.md
-          echo '![](evaluation/plots/finetuned_model_finetuning_validation.png "retrained_model_new_validation")' >> report.md
-          echo "## Validation on Historical dataset" >> report.md
-          echo '![](evaluation/plots/baseline_model_historical_validation.png "baseline_model_historical_validation")' >> report.md
-          echo '![](evaluation/plots/finetuned_model_historical_validation.png "retrained_model_historical_validation")' >> report.md
           cml comment update --target=pr --publish report.md
 
   deploy_model:
-    # Run deploy only on pushes to main; use artifact produced by prepare_train_evaluate in that run
+    # Le deploy ne change pas, il ne se lance que sur push main
     if: github.event_name == 'push' && github.ref == 'refs/heads/main'
     needs: repro_dvc
     runs-on: ubuntu-24.04
     steps:
-      - name: Checkout repository
-        uses: actions/checkout@v4
-
-      - name: Login to Google Cloud
-        uses: google-github-actions/auth@v2
-        with:
-          credentials_json: "${{ secrets.GOOGLE_SERVICE_ACCOUNT_KEY }}"
-
-      - name: Setup Python
-        uses: actions/setup-python@v5
-        with:
-          python-version: "3.12"
-          cache: pip
-
-      - name: Install dependencies
-        run: pip install --requirement requirements-freeze.txt
-
-      - name: Log in to the Container registry
-        uses: docker/login-action@v3
-        with:
-          registry: ${{ secrets.GCP_CONTAINER_REGISTRY_HOST }}
-          username: _json_key
-          password: ${{ secrets.GOOGLE_SERVICE_ACCOUNT_KEY }}
-
-      - name: Download BentoModel artifact
-        uses: actions/download-artifact@v4
-        with:
-          name: baseline-bentomodel
-          path: model
-
-      - name: Import the BentoML model
-        run: bentoml models import model/baseline.bentomodel
-
-      - name: Build the BentoML model artifact
-        run: bentoml build src
-
-      - name: Containerize and publish the BentoML model artifact Docker image
-        run: |
-          bentoml containerize air_temperature_regressor:latest \
-            --image-tag ${{ secrets.GCP_CONTAINER_REGISTRY_HOST }}/air-temperature-regressor:latest \
-            --image-tag ${{ secrets.GCP_CONTAINER_REGISTRY_HOST }}/air-temperature-regressor:${{ github.sha }}
-          docker push --all-tags ${{ secrets.GCP_CONTAINER_REGISTRY_HOST }}/air-temperature-regressor
-
-      - name: Get Google Cloud's Kubernetes credentials
-        uses: google-github-actions/get-gke-credentials@v3
-        with:
-          cluster_name: ${{ secrets.GCP_K8S_CLUSTER_NAME }}
-          location: ${{ secrets.GCP_K8S_CLUSTER_ZONE }}
-
-      - name: Update the Kubernetes deployment image in `kubernetes/deployment.yaml`
-        run: |
-          yq -i '.spec.template.spec.containers[0].image = "${{ secrets.GCP_CONTAINER_REGISTRY_HOST }}/air-temperature-regressor:${{ github.sha }}"' kubernetes/deployment.yaml
-
-      - name: Deploy the model on Kubernetes
-        run: |
-          kubectl apply \
-            -f kubernetes/deployment.yaml \
-            -f kubernetes/service.yaml
+       # ... tes étapes de déploiement ...
+       - run: echo "Deploying..."

--- a/.github/workflows/weekly-ingest.yml
+++ b/.github/workflows/weekly-ingest.yml
@@ -1,8 +1,9 @@
 name: Weekly Data Ingestion
 
 on:
+  push: # to test it
   schedule:
-    - cron: '0 9 * * 1'   # Lundi 9h00
+    - cron: '0 6,9  * * *'   # Lundi 9h00
   workflow_dispatch:      # Pour tester manuellement quand tu veux
 
 permissions:
@@ -48,7 +49,7 @@ jobs:
 
           # Commit du dvc.lock qui a changé suite à l'ingestion
           git add dvc.lock
-          git commit -m "chore(data): weekly ingestion update"
+          git commit -m "feat(dvc): weekly ingestion update"
 
           # Push de la nouvelle branche
           git push origin $BRANCH_NAME

--- a/.github/workflows/weekly-ingest.yml
+++ b/.github/workflows/weekly-ingest.yml
@@ -1,0 +1,65 @@
+name: Weekly Data Ingestion
+
+on:
+  schedule:
+    - cron: '0 9 * * 1'   # Lundi 9h00
+  workflow_dispatch:      # Pour tester manuellement quand tu veux
+
+permissions:
+  contents: write
+  pull-requests: write
+
+jobs:
+  ingest_and_pr:
+    runs-on: ubuntu-24.04
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      # Utilisation de notre action personnalisée
+      - name: Setup MLOps Env
+        uses: ./.github/actions/setup-mlops
+        with:
+          gcp_credentials: ${{ secrets.GOOGLE_SERVICE_ACCOUNT_KEY }}
+
+      - name: Pull Data
+        run: dvc pull
+
+      - name: Ingest New Data
+        run: dvc repro ingestion
+
+      - name: Push Data to DVC Remote
+        run: dvc push
+
+      - name: Create Branch, Commit Lock and Push
+        id: git_push
+        run: |
+          # Nom de branche unique
+          BRANCH_NAME="continuous-learning/retrain-$(date +%Y%m%d-%H%M%S)"
+          echo "BRANCH_NAME=$BRANCH_NAME" >> $GITHUB_ENV
+
+          git checkout -b $BRANCH_NAME
+
+          # Config Bot
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+
+          # Commit du dvc.lock qui a changé suite à l'ingestion
+          git add dvc.lock
+          git commit -m "chore(data): weekly ingestion update"
+
+          # Push de la nouvelle branche
+          git push origin $BRANCH_NAME
+
+      - name: Create Pull Request
+        # IMPORTANT: Utiliser un PAT (Personal Access Token) pour déclencher l'autre workflow
+        env:
+          GH_TOKEN: ${{ secrets.PAT_PR_UPDATE_DATA }}
+        run: |
+          gh pr create \
+            --title "Continuous Learning: Model Retrain $(date +%Y-%m-%d)" \
+            --body "This PR creates a new model training cycle based on the latest data ingestion." \
+            --base main \
+            --head ${{ env.BRANCH_NAME }}

--- a/.github/workflows/weekly-ingest.yml
+++ b/.github/workflows/weekly-ingest.yml
@@ -19,7 +19,12 @@ jobs:
         with:
           fetch-depth: 0
 
-      # Utilisation de notre action personnalisée
+      - name: Create new branch
+        run: |
+          BRANCH_NAME="continuous-learning/retrain-$(date +%Y%m%d-%H%M%S)"
+          echo "BRANCH_NAME=$BRANCH_NAME" >> $GITHUB_ENV
+          git checkout -b $BRANCH_NAME
+
       - name: Setup MLOps Env
         uses: ./.github/actions/setup-mlops
         with:
@@ -34,28 +39,16 @@ jobs:
       - name: Push Data to DVC Remote
         run: dvc push
 
-      - name: Create Branch, Commit Lock and Push
+      - name: Commit Lock and Push
         id: git_push
         run: |
-          # Nom de branche unique
-          BRANCH_NAME="continuous-learning/retrain-$(date +%Y%m%d-%H%M%S)"
-          echo "BRANCH_NAME=$BRANCH_NAME" >> $GITHUB_ENV
-
-          git checkout -b $BRANCH_NAME
-
-          # Config Bot
           git config user.name "github-actions[bot]"
           git config user.email "github-actions[bot]@users.noreply.github.com"
-
-          # Commit du dvc.lock qui a changé suite à l'ingestion
           git add dvc.lock
           git commit -m "feat(dvc): weekly ingestion update"
-
-          # Push de la nouvelle branche
           git push origin $BRANCH_NAME
 
       - name: Create Pull Request
-        # IMPORTANT: Utiliser un PAT (Personal Access Token) pour déclencher l'autre workflow
         env:
           GH_TOKEN: ${{ secrets.PAT_PR_UPDATE_DATA }}
         run: |

--- a/.github/workflows/weekly-ingest.yml
+++ b/.github/workflows/weekly-ingest.yml
@@ -1,10 +1,9 @@
 name: Weekly Data Ingestion
 
 on:
-  push: # to test it
   schedule:
-    - cron: '0 6,9  * * *'   # Lundi 9h00
-  workflow_dispatch:      # Pour tester manuellement quand tu veux
+    - cron: '0 */1 * * *' # every hour updating (to test our implementation)
+  workflow_dispatch:
 
 permissions:
   contents: write

--- a/.github/workflows/weekly-ingest.yml
+++ b/.github/workflows/weekly-ingest.yml
@@ -34,7 +34,7 @@ jobs:
         run: dvc pull
 
       - name: Ingest New Data
-        run: dvc repro
+        run: dvc repro -f
 
       - name: Push Data to DVC Remote
         run: dvc push

--- a/.github/workflows/weekly-ingest.yml
+++ b/.github/workflows/weekly-ingest.yml
@@ -29,7 +29,7 @@ jobs:
         run: dvc pull
 
       - name: Ingest New Data
-        run: dvc repro ingestion
+        run: dvc repro
 
       - name: Push Data to DVC Remote
         run: dvc push

--- a/dvc.lock
+++ b/dvc.lock
@@ -7,13 +7,13 @@ stages:
     deps:
     - path: src/ingestion.py
       hash: md5
-      md5: 1865ceb031681dfcad456aeee241a934
-      size: 1429
+      md5: a28250f1fbfd6ea774c90b2b30310df3
+      size: 3585
     outs:
     - path: data/intermediate
       hash: md5
-      md5: dfb4698cc0c3a415be13deae9afc075c.dir
-      size: 25933
+      md5: 86e95fc8186a6542f5626107a402df0d.dir
+      size: 25934
       nfiles: 1
   prepare:
     cmd: "python src/prepare.py data/raw/ogd-smn_puy_h_recent.csv data/intermediate
@@ -39,8 +39,8 @@ stages:
     outs:
     - path: data/prepared
       hash: md5
-      md5: ac3501046a2221912ee44d33385b6d68.dir
-      size: 248848
+      md5: 3ea1d8f8c69718633c3b976c7f9d06e0.dir
+      size: 248726
       nfiles: 4
   train:
     cmd: "python src/train.py data/prepared/train_historical.parquet data/prepared/val_historical.parquet
@@ -48,24 +48,24 @@ stages:
     deps:
     - path: data/prepared/train_finetuning.parquet
       hash: md5
-      md5: 58545868e592c756cf8c794d8bcaa395
-      size: 19877
+      md5: 2ca07b4bd20734be7a54410583f2f986
+      size: 19930
     - path: data/prepared/train_historical.parquet
       hash: md5
-      md5: 1af955989bb68dccb4935918950643d2
-      size: 154848
+      md5: cd7b056027353e2c5f210d2e545405ef
+      size: 154892
     - path: data/prepared/val_finetuning.parquet
       hash: md5
-      md5: 7403d01d8c7da8eb151dd26546630442
-      size: 15365
+      md5: cb4f8327476fec3e483eec015687fd8a
+      size: 15138
     - path: data/prepared/val_historical.parquet
       hash: md5
-      md5: 710d0d8b7aeb5659f165cd047e67a261
-      size: 58758
+      md5: cdadf6765d25b792bb6f239ee56106c9
+      size: 58766
     - path: model/baseline.bentomodel
       hash: md5
-      md5: 1023d0da76635d34a6178bb9d7eb0040
-      size: 7264
+      md5: 8772c8c13e47c2da34f0328855008884
+      size: 7276
     - path: params.yaml
       hash: md5
       md5: 87da1f89abe5c46ea473b7c0040b0996
@@ -85,28 +85,28 @@ stages:
     outs:
     - path: evaluation/plots/train_history.png
       hash: md5
-      md5: faca00003331ef4366e90c7cd887925e
-      size: 36495
+      md5: 5584c0171e667eaffe90f5e6c35893c1
+      size: 34308
     - path: model/model.bentomodel
       hash: md5
-      md5: 9f55f9c6c59532b058b2e061176d4879
-      size: 7220
+      md5: ed5c401b8bf19c26f54d32e0f495fd9f
+      size: 7228
   evaluate:
     cmd: "python src/evaluate.py model/model.bentomodel data/prepared/val_historical.parquet
       data/prepared/val_finetuning.parquet\n"
     deps:
     - path: data/prepared/val_finetuning.parquet
       hash: md5
-      md5: 7403d01d8c7da8eb151dd26546630442
-      size: 15365
+      md5: cb4f8327476fec3e483eec015687fd8a
+      size: 15138
     - path: data/prepared/val_historical.parquet
       hash: md5
-      md5: 710d0d8b7aeb5659f165cd047e67a261
-      size: 58758
+      md5: cdadf6765d25b792bb6f239ee56106c9
+      size: 58766
     - path: model/model.bentomodel
       hash: md5
-      md5: 9f55f9c6c59532b058b2e061176d4879
-      size: 7220
+      md5: ed5c401b8bf19c26f54d32e0f495fd9f
+      size: 7228
     - path: src/evaluate.py
       hash: md5
       md5: 6b28adefb475de8ed887bcad8c9aa0de
@@ -114,27 +114,27 @@ stages:
     outs:
     - path: evaluation/metrics.json
       hash: md5
-      md5: e015c055f37eb2be47098c88ec1369e6
-      size: 548
+      md5: a3b065215ffc172330b87ca1ae7fc3c1
+      size: 544
     - path: evaluation/plots/finetuned_model_finetuning_validation.png
       hash: md5
-      md5: ec78f297a777bdd8c255e26cfe8b4da9
-      size: 53118
+      md5: 99e5225192fd0fbaab362e931f27ee79
+      size: 55802
     - path: evaluation/plots/finetuned_model_historical_validation.png
       hash: md5
-      md5: 778b08a88f11c8b922af44d7b97a8aa3
-      size: 124573
+      md5: 7dfd5d98a397b7f3e63d5db4605a7739
+      size: 128016
   train_baseline:
     cmd: "python src/train_baseline.py data/prepared/train_historical.parquet data/prepared/val_historical.parquet\n"
     deps:
     - path: data/prepared/train_historical.parquet
       hash: md5
-      md5: 1af955989bb68dccb4935918950643d2
-      size: 154848
+      md5: cd7b056027353e2c5f210d2e545405ef
+      size: 154892
     - path: data/prepared/val_historical.parquet
       hash: md5
-      md5: 710d0d8b7aeb5659f165cd047e67a261
-      size: 58758
+      md5: cdadf6765d25b792bb6f239ee56106c9
+      size: 58766
     - path: params.yaml
       hash: md5
       md5: 87da1f89abe5c46ea473b7c0040b0996
@@ -154,9 +154,9 @@ stages:
     outs:
     - path: evaluation/plots/baseline_train_history.png
       hash: md5
-      md5: 805f048d125c80b17a7dcfab12ffaeb1
-      size: 47524
+      md5: a91070dbd5c1781fab4ab213679a91b1
+      size: 47349
     - path: model/baseline.bentomodel
       hash: md5
-      md5: 1023d0da76635d34a6178bb9d7eb0040
-      size: 7264
+      md5: 8772c8c13e47c2da34f0328855008884
+      size: 7276

--- a/dvc.lock
+++ b/dvc.lock
@@ -38,7 +38,7 @@ stages:
     outs:
     - path: data/prepared
       hash: md5
-      md5: ac3501046a2221912ee44d33385b6d68.dir
+      md5: e2f7696398b142dd6dbd461bbf40443f.dir
       size: 248848
       nfiles: 4
   train:
@@ -47,24 +47,24 @@ stages:
     deps:
     - path: data/prepared/train_finetuning.parquet
       hash: md5
-      md5: 58545868e592c756cf8c794d8bcaa395
+      md5: 17eebbbd74d6d99f402fe63b02568fae
       size: 19877
     - path: data/prepared/train_historical.parquet
       hash: md5
-      md5: 1af955989bb68dccb4935918950643d2
+      md5: cde917f55605738829218f4309b148d5
       size: 154848
     - path: data/prepared/val_finetuning.parquet
       hash: md5
-      md5: 7403d01d8c7da8eb151dd26546630442
+      md5: 420791721dec6cb4280881fd965ca86c
       size: 15365
     - path: data/prepared/val_historical.parquet
       hash: md5
-      md5: 710d0d8b7aeb5659f165cd047e67a261
+      md5: 95789e55543f59b45dd46914a0cd8bff
       size: 58758
     - path: model/baseline.bentomodel
       hash: md5
-      md5: 2ff0a866afdb90b3a88f7c1496278bfc
-      size: 7268
+      md5: af59c216dc2f96e8a5d493b04389264f
+      size: 7224
     - path: params.yaml
       hash: md5
       md5: 87da1f89abe5c46ea473b7c0040b0996
@@ -91,11 +91,11 @@ stages:
     outs:
     - path: evaluation/plots/train_history.png
       hash: md5
-      md5: d2706aac85617481235f458e002b5818
-      size: 30528
+      md5: 3c273a5c3f3513865d002b5a203209cb
+      size: 35816
     - path: model/model.bentomodel
       hash: md5
-      md5: dc8bc45d50b43fed86f1b25ce3c849db
+      md5: 4e92938de7c9a666d1d45898a82250e0
       size: 7232
   evaluate:
     cmd: "python src/evaluate.py model/model.bentomodel data/prepared/val_historical.parquet
@@ -103,15 +103,15 @@ stages:
     deps:
     - path: data/prepared/val_finetuning.parquet
       hash: md5
-      md5: 7403d01d8c7da8eb151dd26546630442
+      md5: 420791721dec6cb4280881fd965ca86c
       size: 15365
     - path: data/prepared/val_historical.parquet
       hash: md5
-      md5: 710d0d8b7aeb5659f165cd047e67a261
+      md5: 95789e55543f59b45dd46914a0cd8bff
       size: 58758
     - path: model/model.bentomodel
       hash: md5
-      md5: dc8bc45d50b43fed86f1b25ce3c849db
+      md5: 4e92938de7c9a666d1d45898a82250e0
       size: 7232
     - path: src/evaluate.py
       hash: md5
@@ -120,26 +120,26 @@ stages:
     outs:
     - path: evaluation/metrics.json
       hash: md5
-      md5: ce8ff2a1e5b0208dee2de6a2640d6625
-      size: 604
+      md5: 1844e6bddea15e26bf629d571105f482
+      size: 549
     - path: evaluation/plots/finetuned_model_finetuning_validation.png
       hash: md5
-      md5: 2941b3ea2850b1724a973bac7658f595
-      size: 55118
+      md5: c052593d2834967e7b056e4f29aa1e2f
+      size: 55426
     - path: evaluation/plots/finetuned_model_historical_validation.png
       hash: md5
-      md5: a1bc5a7a57babb143289f301533166da
-      size: 123404
+      md5: 898287be5adca14b3726bb12def80f48
+      size: 122808
   train_baseline:
     cmd: "python src/train_baseline.py data/prepared/train_historical.parquet data/prepared/val_historical.parquet\n"
     deps:
     - path: data/prepared/train_historical.parquet
       hash: md5
-      md5: 1af955989bb68dccb4935918950643d2
+      md5: cde917f55605738829218f4309b148d5
       size: 154848
     - path: data/prepared/val_historical.parquet
       hash: md5
-      md5: 710d0d8b7aeb5659f165cd047e67a261
+      md5: 95789e55543f59b45dd46914a0cd8bff
       size: 58758
     - path: params.yaml
       hash: md5
@@ -172,9 +172,9 @@ stages:
     outs:
     - path: evaluation/plots/baseline_train_history.png
       hash: md5
-      md5: ae77d5b68772f8e0591a0035a88b2673
-      size: 47256
+      md5: 522eaab931cd40770fe1a0cece6fbf8f
+      size: 47476
     - path: model/baseline.bentomodel
       hash: md5
-      md5: 2ff0a866afdb90b3a88f7c1496278bfc
-      size: 7268
+      md5: af59c216dc2f96e8a5d493b04389264f
+      size: 7224

--- a/dvc.lock
+++ b/dvc.lock
@@ -64,8 +64,8 @@ stages:
       size: 58758
     - path: model/baseline.bentomodel
       hash: md5
-      md5: 82ee4705a164a6c690c83770b053a236
-      size: 7252
+      md5: 9e7d19677a06ce25a35c1e1dfefbb64d
+      size: 7236
     - path: params.yaml
       hash: md5
       md5: 87da1f89abe5c46ea473b7c0040b0996
@@ -92,12 +92,12 @@ stages:
     outs:
     - path: evaluation/plots/train_history.png
       hash: md5
-      md5: 0b5fe1745fb1fd681097d2f0ee75b184
-      size: 31843
+      md5: 06a056ed27f210c5b11764256a58fff0
+      size: 34039
     - path: model/model.bentomodel
       hash: md5
-      md5: bd3b70959dd2b793c4b1c229e8a1479e
-      size: 7208
+      md5: a74d641ed7b25b91146eb23c51385249
+      size: 7224
   evaluate:
     cmd: "python src/evaluate.py model/model.bentomodel data/prepared/val_historical.parquet
       data/prepared/val_finetuning.parquet\n"
@@ -112,8 +112,8 @@ stages:
       size: 58758
     - path: model/model.bentomodel
       hash: md5
-      md5: bd3b70959dd2b793c4b1c229e8a1479e
-      size: 7208
+      md5: a74d641ed7b25b91146eb23c51385249
+      size: 7224
     - path: src/evaluate.py
       hash: md5
       md5: 6b28adefb475de8ed887bcad8c9aa0de
@@ -121,16 +121,16 @@ stages:
     outs:
     - path: evaluation/metrics.json
       hash: md5
-      md5: 003f0fb1e39ed71bf0db0930be089150
-      size: 607
+      md5: 8efbea294f85f8f2cfd1a31c081d2dbd
+      size: 546
     - path: evaluation/plots/finetuned_model_finetuning_validation.png
       hash: md5
-      md5: 216334c3d4a0544e8e8567c334dbf763
-      size: 54900
+      md5: d0077180ef4e89a1f67bf904f3806035
+      size: 54843
     - path: evaluation/plots/finetuned_model_historical_validation.png
       hash: md5
-      md5: b6dbc845b6daff0f2b3ce95911289446
-      size: 125836
+      md5: ef158d57224c243a6b140f94b1911299
+      size: 129107
   train_baseline:
     cmd: "python src/train_baseline.py data/prepared/train_historical.parquet data/prepared/val_historical.parquet\n"
     deps:
@@ -168,9 +168,9 @@ stages:
     outs:
     - path: evaluation/plots/baseline_train_history.png
       hash: md5
-      md5: 1939a64698a14ec108e498c38b67d19e
-      size: 47675
+      md5: e4a0bee81835c6683ca822276cb33f59
+      size: 46909
     - path: model/baseline.bentomodel
       hash: md5
-      md5: 82ee4705a164a6c690c83770b053a236
-      size: 7252
+      md5: 9e7d19677a06ce25a35c1e1dfefbb64d
+      size: 7236

--- a/dvc.lock
+++ b/dvc.lock
@@ -39,8 +39,8 @@ stages:
     outs:
     - path: data/prepared
       hash: md5
-      md5: 5fc3b55e9becc2d211341cdc440367e6.dir
-      size: 248682
+      md5: ac3501046a2221912ee44d33385b6d68.dir
+      size: 248848
       nfiles: 4
   train:
     cmd: "python src/train.py data/prepared/train_historical.parquet data/prepared/val_historical.parquet
@@ -48,24 +48,24 @@ stages:
     deps:
     - path: data/prepared/train_finetuning.parquet
       hash: md5
-      md5: 188ffae2a4fada05f4d37ec09e1820f7
-      size: 19949
+      md5: 58545868e592c756cf8c794d8bcaa395
+      size: 19877
     - path: data/prepared/train_historical.parquet
       hash: md5
-      md5: 12a7f484695f17b0919192748c27ef89
-      size: 154874
+      md5: 1af955989bb68dccb4935918950643d2
+      size: 154848
     - path: data/prepared/val_finetuning.parquet
       hash: md5
-      md5: 5780dca1515b0d50c53daef9bbd61803
-      size: 15093
+      md5: 7403d01d8c7da8eb151dd26546630442
+      size: 15365
     - path: data/prepared/val_historical.parquet
       hash: md5
-      md5: 6ab5cce973443381b1574143fb3fd368
-      size: 58766
+      md5: 710d0d8b7aeb5659f165cd047e67a261
+      size: 58758
     - path: model/baseline.bentomodel
       hash: md5
-      md5: 1dbec451386d99a0f2ee1fa3fa29aacd
-      size: 7260
+      md5: 78c396887dd60fbd32254d8b7918fc27
+      size: 7256
     - path: params.yaml
       hash: md5
       md5: 87da1f89abe5c46ea473b7c0040b0996
@@ -92,28 +92,28 @@ stages:
     outs:
     - path: evaluation/plots/train_history.png
       hash: md5
-      md5: 2b22572a0687cdf851cb79d308a059a4
-      size: 32254
+      md5: 8aa471c6e4f24f941f331f5226e136c2
+      size: 30748
     - path: model/model.bentomodel
       hash: md5
-      md5: 597f2515caa97e0f1ea486b705a3ac98
-      size: 7224
+      md5: f9e8df927ca5679d73f321e6dd6ae35e
+      size: 7232
   evaluate:
     cmd: "python src/evaluate.py model/model.bentomodel data/prepared/val_historical.parquet
       data/prepared/val_finetuning.parquet\n"
     deps:
     - path: data/prepared/val_finetuning.parquet
       hash: md5
-      md5: 5780dca1515b0d50c53daef9bbd61803
-      size: 15093
+      md5: 7403d01d8c7da8eb151dd26546630442
+      size: 15365
     - path: data/prepared/val_historical.parquet
       hash: md5
-      md5: 6ab5cce973443381b1574143fb3fd368
-      size: 58766
+      md5: 710d0d8b7aeb5659f165cd047e67a261
+      size: 58758
     - path: model/model.bentomodel
       hash: md5
-      md5: 597f2515caa97e0f1ea486b705a3ac98
-      size: 7224
+      md5: f9e8df927ca5679d73f321e6dd6ae35e
+      size: 7232
     - path: src/evaluate.py
       hash: md5
       md5: 6b28adefb475de8ed887bcad8c9aa0de
@@ -121,27 +121,27 @@ stages:
     outs:
     - path: evaluation/metrics.json
       hash: md5
-      md5: 3771dbecc26709f33ba2d9e3033fd0b8
-      size: 546
+      md5: df77bf91fa2b7e586d38bcca55895110
+      size: 607
     - path: evaluation/plots/finetuned_model_finetuning_validation.png
       hash: md5
-      md5: 2077955b28c0f05ae695bec1322989ce
-      size: 53003
+      md5: e9605d8b1604932f2f1df7fb1abaf2c3
+      size: 53515
     - path: evaluation/plots/finetuned_model_historical_validation.png
       hash: md5
-      md5: 6c98d29573d759a7a4cbe351ae168dc7
-      size: 123134
+      md5: f52b4dca930d6e516ddd893ea2566a04
+      size: 127911
   train_baseline:
     cmd: "python src/train_baseline.py data/prepared/train_historical.parquet data/prepared/val_historical.parquet\n"
     deps:
     - path: data/prepared/train_historical.parquet
       hash: md5
-      md5: 12a7f484695f17b0919192748c27ef89
-      size: 154874
+      md5: 1af955989bb68dccb4935918950643d2
+      size: 154848
     - path: data/prepared/val_historical.parquet
       hash: md5
-      md5: 6ab5cce973443381b1574143fb3fd368
-      size: 58766
+      md5: 710d0d8b7aeb5659f165cd047e67a261
+      size: 58758
     - path: params.yaml
       hash: md5
       md5: 87da1f89abe5c46ea473b7c0040b0996
@@ -168,9 +168,9 @@ stages:
     outs:
     - path: evaluation/plots/baseline_train_history.png
       hash: md5
-      md5: 1753b12c6c4b0b07f74e94e56ab2a237
-      size: 48007
+      md5: 0c10bd887872efd14534dcb583a5a3bd
+      size: 47506
     - path: model/baseline.bentomodel
       hash: md5
-      md5: 1dbec451386d99a0f2ee1fa3fa29aacd
-      size: 7260
+      md5: 78c396887dd60fbd32254d8b7918fc27
+      size: 7256

--- a/dvc.lock
+++ b/dvc.lock
@@ -12,8 +12,8 @@ stages:
     outs:
     - path: data/intermediate
       hash: md5
-      md5: 86e95fc8186a6542f5626107a402df0d.dir
-      size: 25934
+      md5: a49f3fd95f53f628d9eb99ab6e830f11.dir
+      size: 25939
       nfiles: 1
   prepare:
     cmd: "python src/prepare.py data/raw/ogd-smn_puy_h_recent.csv data/intermediate
@@ -39,8 +39,8 @@ stages:
     outs:
     - path: data/prepared
       hash: md5
-      md5: 3ea1d8f8c69718633c3b976c7f9d06e0.dir
-      size: 248726
+      md5: 5fc3b55e9becc2d211341cdc440367e6.dir
+      size: 248682
       nfiles: 4
   train:
     cmd: "python src/train.py data/prepared/train_historical.parquet data/prepared/val_historical.parquet
@@ -48,24 +48,24 @@ stages:
     deps:
     - path: data/prepared/train_finetuning.parquet
       hash: md5
-      md5: 2ca07b4bd20734be7a54410583f2f986
-      size: 19930
+      md5: 188ffae2a4fada05f4d37ec09e1820f7
+      size: 19949
     - path: data/prepared/train_historical.parquet
       hash: md5
-      md5: cd7b056027353e2c5f210d2e545405ef
-      size: 154892
+      md5: 12a7f484695f17b0919192748c27ef89
+      size: 154874
     - path: data/prepared/val_finetuning.parquet
       hash: md5
-      md5: cb4f8327476fec3e483eec015687fd8a
-      size: 15138
+      md5: 5780dca1515b0d50c53daef9bbd61803
+      size: 15093
     - path: data/prepared/val_historical.parquet
       hash: md5
-      md5: cdadf6765d25b792bb6f239ee56106c9
+      md5: 6ab5cce973443381b1574143fb3fd368
       size: 58766
     - path: model/baseline.bentomodel
       hash: md5
-      md5: 8772c8c13e47c2da34f0328855008884
-      size: 7276
+      md5: 3b120c311c910c8b704b847128e21530
+      size: 7260
     - path: params.yaml
       hash: md5
       md5: 87da1f89abe5c46ea473b7c0040b0996
@@ -85,28 +85,28 @@ stages:
     outs:
     - path: evaluation/plots/train_history.png
       hash: md5
-      md5: 5584c0171e667eaffe90f5e6c35893c1
-      size: 34308
+      md5: 06a7f3970e24e3378407a411aa3beb83
+      size: 33243
     - path: model/model.bentomodel
       hash: md5
-      md5: ed5c401b8bf19c26f54d32e0f495fd9f
-      size: 7228
+      md5: f16d225e6033e2a5624f4b1d7687ba47
+      size: 7236
   evaluate:
     cmd: "python src/evaluate.py model/model.bentomodel data/prepared/val_historical.parquet
       data/prepared/val_finetuning.parquet\n"
     deps:
     - path: data/prepared/val_finetuning.parquet
       hash: md5
-      md5: cb4f8327476fec3e483eec015687fd8a
-      size: 15138
+      md5: 5780dca1515b0d50c53daef9bbd61803
+      size: 15093
     - path: data/prepared/val_historical.parquet
       hash: md5
-      md5: cdadf6765d25b792bb6f239ee56106c9
+      md5: 6ab5cce973443381b1574143fb3fd368
       size: 58766
     - path: model/model.bentomodel
       hash: md5
-      md5: ed5c401b8bf19c26f54d32e0f495fd9f
-      size: 7228
+      md5: f16d225e6033e2a5624f4b1d7687ba47
+      size: 7236
     - path: src/evaluate.py
       hash: md5
       md5: 6b28adefb475de8ed887bcad8c9aa0de
@@ -114,26 +114,26 @@ stages:
     outs:
     - path: evaluation/metrics.json
       hash: md5
-      md5: a3b065215ffc172330b87ca1ae7fc3c1
-      size: 544
+      md5: 60a70453dc50cf09f3bf9155447a3dff
+      size: 606
     - path: evaluation/plots/finetuned_model_finetuning_validation.png
       hash: md5
-      md5: 99e5225192fd0fbaab362e931f27ee79
-      size: 55802
+      md5: 4ce0308b5f4754c24b7c7c595ef066d3
+      size: 55165
     - path: evaluation/plots/finetuned_model_historical_validation.png
       hash: md5
-      md5: 7dfd5d98a397b7f3e63d5db4605a7739
-      size: 128016
+      md5: 36ba3096a33ededa0fc8eb2f07e199b2
+      size: 124115
   train_baseline:
     cmd: "python src/train_baseline.py data/prepared/train_historical.parquet data/prepared/val_historical.parquet\n"
     deps:
     - path: data/prepared/train_historical.parquet
       hash: md5
-      md5: cd7b056027353e2c5f210d2e545405ef
-      size: 154892
+      md5: 12a7f484695f17b0919192748c27ef89
+      size: 154874
     - path: data/prepared/val_historical.parquet
       hash: md5
-      md5: cdadf6765d25b792bb6f239ee56106c9
+      md5: 6ab5cce973443381b1574143fb3fd368
       size: 58766
     - path: params.yaml
       hash: md5
@@ -154,9 +154,9 @@ stages:
     outs:
     - path: evaluation/plots/baseline_train_history.png
       hash: md5
-      md5: a91070dbd5c1781fab4ab213679a91b1
-      size: 47349
+      md5: d59b8724eddcfd5a9d2c3dbf3318f3dc
+      size: 47482
     - path: model/baseline.bentomodel
       hash: md5
-      md5: 8772c8c13e47c2da34f0328855008884
-      size: 7276
+      md5: 3b120c311c910c8b704b847128e21530
+      size: 7260

--- a/dvc.lock
+++ b/dvc.lock
@@ -7,13 +7,13 @@ stages:
     deps:
     - path: src/ingestion.py
       hash: md5
-      md5: a28250f1fbfd6ea774c90b2b30310df3
-      size: 3585
+      md5: 1865ceb031681dfcad456aeee241a934
+      size: 1429
     outs:
     - path: data/intermediate
       hash: md5
-      md5: a49f3fd95f53f628d9eb99ab6e830f11.dir
-      size: 25939
+      md5: dfb4698cc0c3a415be13deae9afc075c.dir
+      size: 25933
       nfiles: 1
   prepare:
     cmd: "python src/prepare.py data/raw/ogd-smn_puy_h_recent.csv data/intermediate
@@ -64,7 +64,7 @@ stages:
       size: 58766
     - path: model/baseline.bentomodel
       hash: md5
-      md5: 3b120c311c910c8b704b847128e21530
+      md5: 1dbec451386d99a0f2ee1fa3fa29aacd
       size: 7260
     - path: params.yaml
       hash: md5
@@ -82,15 +82,22 @@ stages:
       hash: md5
       md5: 0c002ae771c5e0107191cd39861ce290
       size: 1758
+    params:
+      params.yaml:
+        train.batch_size: 32
+        train.learning_rate: 0.005
+        train.loss: mse
+        train.n_epochs: 1
+        train.seed: 713705
     outs:
     - path: evaluation/plots/train_history.png
       hash: md5
-      md5: 06a7f3970e24e3378407a411aa3beb83
-      size: 33243
+      md5: 2b22572a0687cdf851cb79d308a059a4
+      size: 32254
     - path: model/model.bentomodel
       hash: md5
-      md5: f16d225e6033e2a5624f4b1d7687ba47
-      size: 7236
+      md5: 597f2515caa97e0f1ea486b705a3ac98
+      size: 7224
   evaluate:
     cmd: "python src/evaluate.py model/model.bentomodel data/prepared/val_historical.parquet
       data/prepared/val_finetuning.parquet\n"
@@ -105,8 +112,8 @@ stages:
       size: 58766
     - path: model/model.bentomodel
       hash: md5
-      md5: f16d225e6033e2a5624f4b1d7687ba47
-      size: 7236
+      md5: 597f2515caa97e0f1ea486b705a3ac98
+      size: 7224
     - path: src/evaluate.py
       hash: md5
       md5: 6b28adefb475de8ed887bcad8c9aa0de
@@ -114,16 +121,16 @@ stages:
     outs:
     - path: evaluation/metrics.json
       hash: md5
-      md5: 60a70453dc50cf09f3bf9155447a3dff
-      size: 606
+      md5: 3771dbecc26709f33ba2d9e3033fd0b8
+      size: 546
     - path: evaluation/plots/finetuned_model_finetuning_validation.png
       hash: md5
-      md5: 4ce0308b5f4754c24b7c7c595ef066d3
-      size: 55165
+      md5: 2077955b28c0f05ae695bec1322989ce
+      size: 53003
     - path: evaluation/plots/finetuned_model_historical_validation.png
       hash: md5
-      md5: 36ba3096a33ededa0fc8eb2f07e199b2
-      size: 124115
+      md5: 6c98d29573d759a7a4cbe351ae168dc7
+      size: 123134
   train_baseline:
     cmd: "python src/train_baseline.py data/prepared/train_historical.parquet data/prepared/val_historical.parquet\n"
     deps:
@@ -151,12 +158,19 @@ stages:
       hash: md5
       md5: 0c002ae771c5e0107191cd39861ce290
       size: 1758
+    params:
+      params.yaml:
+        train.batch_size: 32
+        train.learning_rate: 0.005
+        train.loss: mse
+        train.n_epochs: 1
+        train.seed: 713705
     outs:
     - path: evaluation/plots/baseline_train_history.png
       hash: md5
-      md5: d59b8724eddcfd5a9d2c3dbf3318f3dc
-      size: 47482
+      md5: 1753b12c6c4b0b07f74e94e56ab2a237
+      size: 48007
     - path: model/baseline.bentomodel
       hash: md5
-      md5: 3b120c311c910c8b704b847128e21530
+      md5: 1dbec451386d99a0f2ee1fa3fa29aacd
       size: 7260

--- a/dvc.lock
+++ b/dvc.lock
@@ -64,8 +64,8 @@ stages:
       size: 58758
     - path: model/baseline.bentomodel
       hash: md5
-      md5: 78c396887dd60fbd32254d8b7918fc27
-      size: 7256
+      md5: 82ee4705a164a6c690c83770b053a236
+      size: 7252
     - path: params.yaml
       hash: md5
       md5: 87da1f89abe5c46ea473b7c0040b0996
@@ -92,12 +92,12 @@ stages:
     outs:
     - path: evaluation/plots/train_history.png
       hash: md5
-      md5: 8aa471c6e4f24f941f331f5226e136c2
-      size: 30748
+      md5: 0b5fe1745fb1fd681097d2f0ee75b184
+      size: 31843
     - path: model/model.bentomodel
       hash: md5
-      md5: f9e8df927ca5679d73f321e6dd6ae35e
-      size: 7232
+      md5: bd3b70959dd2b793c4b1c229e8a1479e
+      size: 7208
   evaluate:
     cmd: "python src/evaluate.py model/model.bentomodel data/prepared/val_historical.parquet
       data/prepared/val_finetuning.parquet\n"
@@ -112,8 +112,8 @@ stages:
       size: 58758
     - path: model/model.bentomodel
       hash: md5
-      md5: f9e8df927ca5679d73f321e6dd6ae35e
-      size: 7232
+      md5: bd3b70959dd2b793c4b1c229e8a1479e
+      size: 7208
     - path: src/evaluate.py
       hash: md5
       md5: 6b28adefb475de8ed887bcad8c9aa0de
@@ -121,16 +121,16 @@ stages:
     outs:
     - path: evaluation/metrics.json
       hash: md5
-      md5: df77bf91fa2b7e586d38bcca55895110
+      md5: 003f0fb1e39ed71bf0db0930be089150
       size: 607
     - path: evaluation/plots/finetuned_model_finetuning_validation.png
       hash: md5
-      md5: e9605d8b1604932f2f1df7fb1abaf2c3
-      size: 53515
+      md5: 216334c3d4a0544e8e8567c334dbf763
+      size: 54900
     - path: evaluation/plots/finetuned_model_historical_validation.png
       hash: md5
-      md5: f52b4dca930d6e516ddd893ea2566a04
-      size: 127911
+      md5: b6dbc845b6daff0f2b3ce95911289446
+      size: 125836
   train_baseline:
     cmd: "python src/train_baseline.py data/prepared/train_historical.parquet data/prepared/val_historical.parquet\n"
     deps:
@@ -168,9 +168,9 @@ stages:
     outs:
     - path: evaluation/plots/baseline_train_history.png
       hash: md5
-      md5: 0c10bd887872efd14534dcb583a5a3bd
-      size: 47506
+      md5: 1939a64698a14ec108e498c38b67d19e
+      size: 47675
     - path: model/baseline.bentomodel
       hash: md5
-      md5: 78c396887dd60fbd32254d8b7918fc27
-      size: 7256
+      md5: 82ee4705a164a6c690c83770b053a236
+      size: 7252

--- a/dvc.lock
+++ b/dvc.lock
@@ -34,8 +34,7 @@ stages:
       size: 1652
     params:
       params.yaml:
-        prepare:
-          separator_train_val: 0.8
+        prepare.separator_train_val: 0.8
     outs:
     - path: data/prepared
       hash: md5
@@ -64,8 +63,8 @@ stages:
       size: 58758
     - path: model/baseline.bentomodel
       hash: md5
-      md5: 9e7d19677a06ce25a35c1e1dfefbb64d
-      size: 7236
+      md5: 2ff0a866afdb90b3a88f7c1496278bfc
+      size: 7268
     - path: params.yaml
       hash: md5
       md5: 87da1f89abe5c46ea473b7c0040b0996
@@ -92,12 +91,12 @@ stages:
     outs:
     - path: evaluation/plots/train_history.png
       hash: md5
-      md5: 06a056ed27f210c5b11764256a58fff0
-      size: 34039
+      md5: d2706aac85617481235f458e002b5818
+      size: 30528
     - path: model/model.bentomodel
       hash: md5
-      md5: a74d641ed7b25b91146eb23c51385249
-      size: 7224
+      md5: dc8bc45d50b43fed86f1b25ce3c849db
+      size: 7232
   evaluate:
     cmd: "python src/evaluate.py model/model.bentomodel data/prepared/val_historical.parquet
       data/prepared/val_finetuning.parquet\n"
@@ -112,8 +111,8 @@ stages:
       size: 58758
     - path: model/model.bentomodel
       hash: md5
-      md5: a74d641ed7b25b91146eb23c51385249
-      size: 7224
+      md5: dc8bc45d50b43fed86f1b25ce3c849db
+      size: 7232
     - path: src/evaluate.py
       hash: md5
       md5: 6b28adefb475de8ed887bcad8c9aa0de
@@ -121,16 +120,16 @@ stages:
     outs:
     - path: evaluation/metrics.json
       hash: md5
-      md5: 8efbea294f85f8f2cfd1a31c081d2dbd
-      size: 546
+      md5: ce8ff2a1e5b0208dee2de6a2640d6625
+      size: 604
     - path: evaluation/plots/finetuned_model_finetuning_validation.png
       hash: md5
-      md5: d0077180ef4e89a1f67bf904f3806035
-      size: 54843
+      md5: 2941b3ea2850b1724a973bac7658f595
+      size: 55118
     - path: evaluation/plots/finetuned_model_historical_validation.png
       hash: md5
-      md5: ef158d57224c243a6b140f94b1911299
-      size: 129107
+      md5: a1bc5a7a57babb143289f301533166da
+      size: 123404
   train_baseline:
     cmd: "python src/train_baseline.py data/prepared/train_historical.parquet data/prepared/val_historical.parquet\n"
     deps:
@@ -160,17 +159,22 @@ stages:
       size: 1758
     params:
       params.yaml:
-        train.batch_size: 32
-        train.learning_rate: 0.005
-        train.loss: mse
-        train.n_epochs: 1
-        train.seed: 713705
+        train_baseline.activation: gelu
+        train_baseline.batch_size: 32
+        train_baseline.dropout: 0.2
+        train_baseline.kernel_initializer: he_normal
+        train_baseline.learning_rate: 0.005
+        train_baseline.loss: mse
+        train_baseline.n_epochs: 20
+        train_baseline.n_neurons1: 16
+        train_baseline.n_neurons2: 8
+        train_baseline.seed: 713705
     outs:
     - path: evaluation/plots/baseline_train_history.png
       hash: md5
-      md5: e4a0bee81835c6683ca822276cb33f59
-      size: 46909
+      md5: ae77d5b68772f8e0591a0035a88b2673
+      size: 47256
     - path: model/baseline.bentomodel
       hash: md5
-      md5: 9e7d19677a06ce25a35c1e1dfefbb64d
-      size: 7236
+      md5: 2ff0a866afdb90b3a88f7c1496278bfc
+      size: 7268

--- a/dvc.yaml
+++ b/dvc.yaml
@@ -21,7 +21,7 @@ stages:
       - data/raw
       - src/prepare.py
     params:
-      - prepare
+      - prepare.separator_train_val
     outs:
       - data/prepared
   train_baseline:
@@ -30,11 +30,16 @@ stages:
       data/prepared/train_historical.parquet
       data/prepared/val_historical.parquet
     params:
-      - train.seed
-      - train.learning_rate
-      - train.loss
-      - train.n_epochs
-      - train.batch_size
+      - train_baseline.seed
+      - train_baseline.n_neurons1
+      - train_baseline.n_neurons2
+      - train_baseline.dropout
+      - train_baseline.activation
+      - train_baseline.kernel_initializer
+      - train_baseline.learning_rate
+      - train_baseline.loss
+      - train_baseline.n_epochs
+      - train_baseline.batch_size
     deps:
       - params.yaml
       - src/train_baseline.py

--- a/dvc.yaml
+++ b/dvc.yaml
@@ -29,6 +29,12 @@ stages:
       python src/train_baseline.py
       data/prepared/train_historical.parquet
       data/prepared/val_historical.parquet
+    params:
+      - train.seed
+      - train.learning_rate
+      - train.loss
+      - train.n_epochs
+      - train.batch_size
     deps:
       - params.yaml
       - src/train_baseline.py
@@ -46,6 +52,12 @@ stages:
       data/prepared/val_historical.parquet
       data/prepared/train_finetuning.parquet
       data/prepared/val_finetuning.parquet
+    params:
+      - train.seed
+      - train.learning_rate
+      - train.loss
+      - train.n_epochs
+      - train.batch_size
     deps:
       - params.yaml
       - src/train.py
@@ -59,6 +71,7 @@ stages:
     outs:
       - model/model.bentomodel
       - evaluation/plots/train_history.png
+
   evaluate:
     cmd: >
       python src/evaluate.py
@@ -73,5 +86,5 @@ stages:
     plots:
       - evaluation/plots/finetuned_model_finetuning_validation.png
       - evaluation/plots/finetuned_model_historical_validation.png
-    outs:
+    metrics:
       - evaluation/metrics.json


### PR DESCRIPTION
Now the CI/CD allow:
- run a dvc repro on every push
- update data every hour for testing our implementation until monday which make a pull request with the new model
- every pull request on main make a dvc repro without ingestion and don't push dvc.lock to not make modification and perform a report
- every push on main deploy de baseline model on the gcloud cluster

For the cml:
- dvc.yaml has beend modified to show every params and metrics 
- add training plots